### PR TITLE
First pass of adding support for cobertura XML output format

### DIFF
--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -16,7 +16,7 @@ struct xcresultparser: ParsableCommand {
         abstract: "xcresultparser \(marketingVersion)\nInterpret binary .xcresult files and print summary in different formats: txt, xml, html or colored cli output."
     )
     
-    @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', or 'cobertura'. In case of 'xml' JUnit format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage must also be passed.")
+    @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', or 'cobertura'. In case of 'xml' JUnit format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage is implied.")
     var outputFormat: String?
     
     @Option(name: .shortAndLong, help: "The name of the project root. If present paths and urls are relative to the specified directory.")
@@ -62,7 +62,7 @@ struct xcresultparser: ParsableCommand {
                 try outputJUnitXML(for: xcresult)
             }
         } else if format == .cobertura {
-            if coverage != 1 { throw ParseError.argumentError }
+            coverage = 1
             try outputCoberturaXML(for: xcresult)
         } else {
             try outputDescription(for: xcresult)

--- a/LICENSE.XcodeCoverageConverter.txt
+++ b/LICENSE.XcodeCoverageConverter.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Thibault Wittemberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ prefix ?= /usr/local
 bindir = $(prefix)/bin
 
 build:
-	swift build -c release --disable-sandbox
+	swift build -c release --disable-sandbox --arch arm64 --arch x86_64
 
 install: build
 	install -d "$(bindir)"
-	install ".build/release/xcresultparser" "$(bindir)"
+	install ".build/apple/Products/Release/xcresultparser" "$(bindir)"
 
 uninstall:
 	rm -rf "$(bindir)/xcresultparser"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Interpret binary .xcresult files and print summary in different formats:
 - txt
 - colored command line output
 - xml
+- cobertura
 - html
 - markdown
 
@@ -75,7 +76,7 @@ You should see the tool respond like this:
 ```
 Error: Missing expected argument '<xcresult-file>'
 
-OVERVIEW: xcresultparser 1.1.4
+OVERVIEW: xcresultparser 1.1.5
 Interpret binary .xcresult files and print summary in different formats: txt,
 xml, html or colored cli output.
 
@@ -87,9 +88,10 @@ ARGUMENTS:
 OPTIONS:
   -o, --output-format <output-format>
                           The output format. It can be either 'txt', 'cli',
-                          'html', 'md' or 'xml'. In case of 'xml' JUnit format
-                          for test results and generic format (Sonarqube) for
-                          coverage data is used.
+                          'html', 'md', 'xml', or 'cobertura'. In case of 'xml'
+                          JUnit format for test results and generic format
+                          (Sonarqube) for coverage data is used. In the case of
+                          'cobertura', --coverage must also be passed.
   -p, --project-root <project-root>
                           The name of the project root. If present paths and
                           urls are relative to the specified directory.
@@ -146,6 +148,14 @@ Create an xml file in generic code coverage xml format:
 ```
 ./xcresultparser -c -o xml test.xcresult > sonar.xml
 ```
+
+### Cobertura XML output
+Create xml file in [Cobertura](https://cobertura.github.io/cobertura/) format:
+```
+./xcresultparser -c -o cobertura test.xcresult > cobertura.xml
+```
+
+Note that some data in this file is currently fake as of this time of writing, but should have accurate line coverage information. It should be good enough for importing into tools like [GitLab coverage visualizer](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html).
 
 ### Markdown output
 Simple markdown formatting for test results. (We use it for display in a Teams Webhook)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ OPTIONS:
                           'html', 'md', 'xml', or 'cobertura'. In case of 'xml'
                           JUnit format for test results and generic format
                           (Sonarqube) for coverage data is used. In the case of
-                          'cobertura', --coverage must also be passed.
+                          'cobertura', --coverage is implied.
   -p, --project-root <project-root>
                           The name of the project root. If present paths and
                           urls are relative to the specified directory.
@@ -152,10 +152,12 @@ Create an xml file in generic code coverage xml format:
 ### Cobertura XML output
 Create xml file in [Cobertura](https://cobertura.github.io/cobertura/) format:
 ```
-./xcresultparser -c -o cobertura test.xcresult > cobertura.xml
+./xcresultparser -o cobertura test.xcresult > cobertura.xml
 ```
 
 Note that some data in this file is currently fake as of this time of writing, but should have accurate line coverage information. It should be good enough for importing into tools like [GitLab coverage visualizer](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html).
+
+It may be desirable to also pass --project-root if you wish to alter the filenames and sources in the Cobertura report (see note below) - this is required for GitLab compatbility.
 
 ### Markdown output
 Simple markdown formatting for test results. (We use it for display in a Teams Webhook)

--- a/Sources/xcresultparser/CoberturaCoverageConverter.swift
+++ b/Sources/xcresultparser/CoberturaCoverageConverter.swift
@@ -1,0 +1,202 @@
+//
+//  CoberturaCoverageConverter.swift
+//  xcresult2text
+//
+//  Created by Eliot Lash on 12.07.22.
+//
+/**
+ MIT License
+
+ Copyright (c) 2020 Thibault Wittemberg
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+import XCResultKit
+
+public class CoberturaCoverageConverter: CoverageConverter {
+    public override func xmlString(quiet: Bool) throws -> String {
+        guard
+            let dtdUrl = URL(string: "http://cobertura.sourceforge.net/xml/coverage-04.dtd"),
+            let dtd = try? XMLDTD(contentsOf: dtdUrl) else {
+                fatalError("DTD could not be constructed")
+        }
+
+        dtd.name = "coverage"
+        dtd.systemID = "http://cobertura.sourceforge.net/xml/coverage-04.dtd"
+
+        let rootElement = self.makeRootElement()
+
+        let doc = XMLDocument(rootElement: rootElement)
+        doc.version = "1.0"
+        doc.dtd = dtd
+        doc.documentContentKind = XMLDocument.ContentKind.xml
+
+        let sourceElement = XMLElement(name: "sources")
+        rootElement.addChild(sourceElement)
+        sourceElement.addChild(XMLElement(name: "source", stringValue: projectRoot.isEmpty ? "." : projectRoot))
+
+        let packagesElement = XMLElement(name: "packages")
+        rootElement.addChild(packagesElement)
+
+        let fileInfoSemaphore = DispatchSemaphore(value: 1)
+        let files = try coverageFileList()
+        var fileInfo: [FileInfo] = []
+        
+        // since we need to invoke xccov for each file, it takes pretty much time
+        // so we invoke it in parallel on 8 threads, that speeds up things considerably
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 8 //Deadlock if this is = 1
+        queue.qualityOfService = .userInitiated
+        for file in files {
+            guard !file.isEmpty else { continue }
+            if !quiet {
+                writeToStdError("Coverage for: \(file)\n")
+            }
+            let op = BlockOperation { [self] in
+                do {
+                    let file = try fileCoverage(for: file, relativeTo: projectRoot)
+                    fileInfoSemaphore.wait()
+                    fileInfo.append(file)
+                    fileInfoSemaphore.signal()
+                } catch {
+                    writeToStdErrorLn(error.localizedDescription)
+                }
+            }
+            queue.addOperation(op)
+        }
+        // This will block until all our operation have compleated (or been canceled)
+        queue.waitUntilAllOperationsAreFinished()
+        
+        // Sort files to avoid duplicated packages
+        fileInfo.sort { $0.path > $1.path }
+        
+        var currentPackage = ""
+        var currentPackageElement: XMLElement!
+        var isNewPackage = false
+
+        var currentClassesElement = XMLElement()
+        
+        fileInfo.forEach { file in
+            let pathComponents = file.path.split(separator: "/")
+            let packageName = pathComponents[0..<pathComponents.count - 1].joined(separator: ".")
+
+            isNewPackage = currentPackage != packageName
+
+            if isNewPackage {
+                currentPackageElement = XMLElement(name: "package")
+                currentClassesElement = XMLElement()
+                packagesElement.addChild(currentPackageElement)
+            }
+
+            currentPackage = packageName
+            if isNewPackage {
+                currentPackageElement.addAttribute(XMLNode.nodeAttribute(withName: "name", stringValue: packageName))
+                currentPackageElement.addAttribute(XMLNode.nodeAttribute(withName: "line-rate", stringValue: "1.0"))
+                currentPackageElement.addAttribute(XMLNode.nodeAttribute(withName: "branch-rate", stringValue: "1.0"))
+                currentPackageElement.addAttribute(XMLNode.nodeAttribute(withName: "complexity", stringValue: "0.0"))
+                currentClassesElement = XMLElement(name: "classes")
+                currentPackageElement.addChild(currentClassesElement)
+            }
+
+            let classElement = XMLElement(name: "class")
+            classElement.addAttribute(XMLNode.nodeAttribute(withName: "name",
+                                                            stringValue: "\(packageName).\((file.path as NSString).deletingPathExtension)"))
+            classElement.addAttribute(XMLNode.nodeAttribute(withName: "filename", stringValue: "\(file.path)"))
+            
+            let fileLineCoverage = Float(file.lines.filter { $0.coverage > 0 }.count) / Float(file.lines.count)
+            classElement.addAttribute(XMLNode.nodeAttribute(withName: "line-rate", stringValue: "\(fileLineCoverage)"))
+            classElement.addAttribute(XMLNode.nodeAttribute(withName: "branch-rate", stringValue: "1.0"))
+            classElement.addAttribute(XMLNode.nodeAttribute(withName: "complexity", stringValue: "0.0"))
+            currentClassesElement.addChild(classElement)
+
+            let linesElement = XMLElement(name: "lines")
+            classElement.addChild(linesElement)
+
+            for line in file.lines {
+                let lineElement = XMLElement(kind: .element, options: .nodeCompactEmptyElement)
+                lineElement.name = "line"
+                lineElement.addAttribute(XMLNode.nodeAttribute(withName: "number", stringValue: "\(line.lineNumber)"))
+                lineElement.addAttribute(XMLNode.nodeAttribute(withName: "branch", stringValue: "false"))
+
+                lineElement.addAttribute(XMLNode.nodeAttribute(withName: "hits", stringValue: "\(line.coverage)"))
+                linesElement.addChild(lineElement)
+            }
+        }
+
+        return doc.xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement])
+    }
+    
+    private func fileCoverage(for file: String, relativeTo projectRoot: String) throws -> FileInfo {
+        let coverageData = try coverageForFile(path: file)
+        var file = FileInfo(path: relativePath(for: file, relativeTo: projectRoot), lines: [])
+        let pattern = #"(\d+):\s*(\d)"#
+        let regex = try NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
+        let nsrange = NSRange(coverageData.startIndex..<coverageData.endIndex,
+                              in: coverageData)
+        regex.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
+            guard let match = match else { return }
+            
+            let lineNumber = coverageData.text(in: match.range(at: 1))
+            let coverage = coverageData.text(in: match.range(at: 2))
+            
+            let line = LineInfo(lineNumber: lineNumber, coverage: Int(coverage) ?? 0)
+            file.lines.append(line)
+        }
+        return file
+    }
+    
+    func makeRootElement() -> XMLElement {
+        // TODO some of these values are B.S. - figure out how to calculate, or better to omit if we don't know?
+        let timeStamp = Date().timeIntervalSince1970
+        let rootElement = XMLElement(name: "coverage")
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "line-rate", stringValue: "\(codeCoverage.lineCoverage)"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "branch-rate", stringValue: "1.0"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "lines-covered", stringValue: "\(codeCoverage.coveredLines)"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "lines-valid", stringValue: "\(codeCoverage.executableLines)"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "timestamp", stringValue: "\(timeStamp)"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "version", stringValue: "diff_coverage 0.1"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "complexity", stringValue: "0.0"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "branches-valid", stringValue: "1.0"))
+        rootElement.addAttribute(XMLNode.nodeAttribute(withName: "branches-covered", stringValue: "1.0"))
+
+        return rootElement
+    }
+}
+
+struct LineInfo {
+    var lineNumber: String
+    var coverage: Int
+}
+
+struct FileInfo {
+    var path: String
+    var lines: [LineInfo]
+}
+
+extension XMLNode {
+    static func nodeAttribute(withName name: String, stringValue value: String) -> XMLNode {
+        guard let attribute = XMLNode.attribute(withName: name, stringValue: value) as? XMLNode else {
+            return XMLNode()
+        }
+
+        return attribute
+    }
+}

--- a/Sources/xcresultparser/CoberturaCoverageConverter.swift
+++ b/Sources/xcresultparser/CoberturaCoverageConverter.swift
@@ -72,9 +72,9 @@ public class CoberturaCoverageConverter: CoverageConverter {
             }
             let op = BlockOperation { [self] in
                 do {
-                    let file = try fileCoverage(for: file, relativeTo: projectRoot)
+                    let coverage = try fileCoverage(for: file, relativeTo: projectRoot)
                     fileInfoSemaphore.wait()
-                    fileInfo.append(file)
+                    fileInfo.append(coverage)
                     fileInfoSemaphore.signal()
                 } catch {
                     writeToStdErrorLn(error.localizedDescription)
@@ -147,11 +147,9 @@ public class CoberturaCoverageConverter: CoverageConverter {
     private func fileCoverage(for file: String, relativeTo projectRoot: String) throws -> FileInfo {
         let coverageData = try coverageForFile(path: file)
         var file = FileInfo(path: relativePath(for: file, relativeTo: projectRoot), lines: [])
-        let pattern = #"(\d+):\s*(\d)"#
-        let regex = try NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
         let nsrange = NSRange(coverageData.startIndex..<coverageData.endIndex,
                               in: coverageData)
-        regex.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
+        coverageRegexp!.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
             guard let match = match else { return }
             
             let lineNumber = coverageData.text(in: match.range(at: 1))
@@ -182,12 +180,12 @@ public class CoberturaCoverageConverter: CoverageConverter {
 }
 
 struct LineInfo {
-    var lineNumber: String
-    var coverage: Int
+    let lineNumber: String
+    let coverage: Int
 }
 
 struct FileInfo {
-    var path: String
+    let path: String
     var lines: [LineInfo]
 }
 

--- a/Sources/xcresultparser/CoverageConverter.swift
+++ b/Sources/xcresultparser/CoverageConverter.swift
@@ -20,9 +20,10 @@ import XCResultKit
 /// which does the same job just in a shell script. It has the same problem
 /// and since it can not spawn it to different threads, it takes about 5x the time.
 public class CoverageConverter {
-    internal let resultFile: XCResultFile
-    internal let projectRoot: String
-    internal let codeCoverage: CodeCoverage
+    let resultFile: XCResultFile
+    let projectRoot: String
+    let codeCoverage: CodeCoverage
+    let coverageRegexp: NSRegularExpression?
     
     public init?(with url: URL,
           projectRoot: String = "") {
@@ -32,17 +33,20 @@ public class CoverageConverter {
         }
         self.projectRoot = projectRoot
         codeCoverage = record
+        
+        let pattern = #"(\d+):\s*(\d)"#
+        coverageRegexp = try? NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
     }
     
     public func xmlString(quiet: Bool) throws -> String {
         fatalError("xmlString is not implemented")
     }
 
-    internal func writeToStdErrorLn(_ str: String) {
+    func writeToStdErrorLn(_ str: String) {
         writeToStdError("\(str)\n")
     }
     
-    internal func writeToStdError(_ str: String) {
+    func writeToStdError(_ str: String) {
         let handle = FileHandle.standardError
 
         if let data = str.data(using: String.Encoding.utf8) {
@@ -50,7 +54,7 @@ public class CoverageConverter {
         }
     }
     
-    internal func relativePath(for path: String, relativeTo projectRoot: String) -> String {
+    func relativePath(for path: String, relativeTo projectRoot: String) -> String {
         guard !projectRoot.isEmpty else {
             return path
         }
@@ -66,7 +70,7 @@ public class CoverageConverter {
     }
     
     
-    internal func coverageFileList() throws -> [String] {
+    func coverageFileList() throws -> [String] {
         var arguments = ["xccov", "view"]
         if resultFile.url.pathExtension == "xcresult" {
             arguments.append("--archive")
@@ -77,7 +81,7 @@ public class CoverageConverter {
         return String(decoding: filelistData, as: UTF8.self).components(separatedBy: "\n")
     }
     
-    internal func coverageForFile(path: String) throws -> String {
+    func coverageForFile(path: String) throws -> String {
         var arguments = ["xccov", "view"]
         if resultFile.url.pathExtension == "xcresult" {
             arguments.append("--archive")

--- a/Sources/xcresultparser/OutputFormatting/OutputFormat.swift
+++ b/Sources/xcresultparser/OutputFormatting/OutputFormat.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum OutputFormat: String {
-    case txt, cli, html, xml, md
+    case txt, cli, html, xml, cobertura, md
     
     public init(string: String?) {
         if let input = string?.lowercased(),

--- a/Sources/xcresultparser/SonarCoverageConverter.swift
+++ b/Sources/xcresultparser/SonarCoverageConverter.swift
@@ -46,11 +46,9 @@ public class SonarCoverageConverter: CoverageConverter {
         let coverageData = try coverageForFile(path: file)
         let fileElement = XMLElement(name: "file")
         fileElement.addAttribute(name: "path", stringValue: relativePath(for: file, relativeTo: projectRoot))
-        let pattern = #"(\d+):\s*(\d)"#
-        let regex = try NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
         let nsrange = NSRange(coverageData.startIndex..<coverageData.endIndex,
                               in: coverageData)
-        regex.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
+        coverageRegexp!.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
             guard let match = match else { return }
             
             let lineNumber = coverageData.text(in: match.range(at: 1))

--- a/Sources/xcresultparser/SonarCoverageConverter.swift
+++ b/Sources/xcresultparser/SonarCoverageConverter.swift
@@ -1,0 +1,68 @@
+//
+//  SonarCoverageConverter.swift
+//  xcresult2text
+//
+//  Created by Alex da Franca on 11.06.21.
+//
+
+import Foundation
+import XCResultKit
+
+public class SonarCoverageConverter: CoverageConverter {
+    public override func xmlString(quiet: Bool) throws -> String {
+        let coverageXML = XMLElement(name: "coverage")
+        coverageXML.addAttribute(name: "version", stringValue: "1")
+        let coverageXMLSemaphore = DispatchSemaphore(value: 1)
+        let files = try coverageFileList()
+        
+        // since we need to invoke xccov for each file, it takes pretty much time
+        // so we invoke it in parallel on 8 threads, that speeds up things considerably
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 8 //Deadlock if this is = 1
+        queue.qualityOfService = .userInitiated
+        for file in files {
+            guard !file.isEmpty else { continue }
+            if !quiet {
+                writeToStdError("Coverage for: \(file)\n")
+            }
+            let op = BlockOperation { [self] in
+                do {
+                    let coverage = try fileCoverageXML(for: file, relativeTo: projectRoot)
+                    coverageXMLSemaphore.wait()
+                    coverageXML.addChild(coverage)
+                    coverageXMLSemaphore.signal()
+                } catch {
+                    writeToStdErrorLn(error.localizedDescription)
+                }
+            }
+            queue.addOperation(op)
+        }
+        // This will block until all our operation have compleated (or been canceled)
+        queue.waitUntilAllOperationsAreFinished()
+        return coverageXML.xmlString(options: [.nodePrettyPrint, .nodeCompactEmptyElement])
+    }
+    
+    private func fileCoverageXML(for file: String, relativeTo projectRoot: String) throws -> XMLElement {
+        let coverageData = try coverageForFile(path: file)
+        let fileElement = XMLElement(name: "file")
+        fileElement.addAttribute(name: "path", stringValue: relativePath(for: file, relativeTo: projectRoot))
+        let pattern = #"(\d+):\s*(\d)"#
+        let regex = try NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
+        let nsrange = NSRange(coverageData.startIndex..<coverageData.endIndex,
+                              in: coverageData)
+        regex.enumerateMatches(in: coverageData, options: [], range: nsrange) { match, flags, stop in
+            guard let match = match else { return }
+            
+            let lineNumber = coverageData.text(in: match.range(at: 1))
+            let coverage = coverageData.text(in: match.range(at: 2))
+            
+            let line = XMLElement(name: "lineToCover")
+            line.addAttribute(name: "lineNumber", stringValue: lineNumber)
+            line.addAttribute(name: "covered", stringValue: (coverage == "0" ? "false": "true"))
+            
+            fileElement.addChild(line)
+            
+        }
+        return fileElement
+    }
+}

--- a/Tests/XcresultparserTests/XcresultparserTests.swift
+++ b/Tests/XcresultparserTests/XcresultparserTests.swift
@@ -105,7 +105,7 @@ Summary
         let projectRoot = ""
         let quiet = 1
 
-        guard let converter = CoverageConverter(with: URL(fileURLWithPath: xcresultFile), projectRoot: projectRoot) else {
+        guard let converter = SonarCoverageConverter(with: URL(fileURLWithPath: xcresultFile), projectRoot: projectRoot) else {
             XCTFail("Unable to create CoverageConverter from \(xcresultFile)")
             return
         }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+swift build -c release --arch arm64 --arch x86_64

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-swift build -c release --arch arm64 --arch x86_64


### PR DESCRIPTION
# Problem statement
I have a need to convert from `.xcresult` to cobertura XML (this format is the only one supported by [GitLab coverage visualizer](https://docs.gitlab.com/ee/ci/testing/test_coverage_visualization.html)) and I couldn't find any other converters that worked directly with `.xcresult` bundle, all the other ones like Slather require an xcode project but I am working from a swift package.

This PR adds a new `cobertura` output format available in coverage mode. The cobertura output formatting code comes from [XcodeCoverageConverter](https://github.com/twittemb/XcodeCoverageConverter) which is also MIT-licensed, and I have added the required license notices for that. The XCC tool does not parse line coverage information but only uses coarse function-level coverage, which is why I abandoned it and switched to forking xcresultparser instead.

Some of the values in the cobertura report are fake, such as cyclomatic complexity, branch-level coverage, and a few instances of aggregate line coverage stats. I think as a first pass I would prefer for these to be out of scope because they would require a lot more effort to calculate. What I have now is good enough for my purposes of importing into GitLab coverage visualizer, and has accurate line-level coverage metrics.

# Summary of changes
* Add new `cobertura` output format
* Make `Makefile` build a universal binary
* Update docs