### PR TITLE
Make TestReportFormat, specifically the `junit` format selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.2.1 - 2023-01-03
+### CHANGES:
+Make output test report format for xml output selectable.
+
 ## Version 1.2.0 - 2022-12-15
 ### CHANGES:
 Added output format for coverage data: cobertura XML (this format is the only one supported by GitLab coverage visualizer). (Credits go to Eliot Lash)

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -16,7 +16,7 @@ struct xcresultparser: ParsableCommand {
         abstract: "xcresultparser \(marketingVersion)\nInterpret binary .xcresult files and print summary in different formats: txt, xml, html or colored cli output."
     )
     
-    @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', or 'cobertura'. In case of 'xml' JUnit format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage is implied.")
+    @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', 'junit', or 'cobertura'. In case of 'xml' sonar generic format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage is implied.")
     var outputFormat: String?
     
     @Option(name: .shortAndLong, help: "The name of the project root. If present paths and urls are relative to the specified directory.")

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -9,7 +9,7 @@ import Foundation
 import ArgumentParser
 import XcresultparserLib
 
-private let marketingVersion = "1.2.0"
+private let marketingVersion = "1.2.1"
 
 struct xcresultparser: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -59,8 +59,10 @@ struct xcresultparser: ParsableCommand {
             if coverage == 1 {
                 try outputSonarXML(for: xcresult)
             } else {
-                try outputJUnitXML(for: xcresult)
+                try outputJUnitXML(for: xcresult, with: .sonar)
             }
+        } else if format == .junit {
+            try outputJUnitXML(for: xcresult, with: .junit)
         } else if format == .cobertura {
             coverage = 1
             try outputCoberturaXML(for: xcresult)
@@ -85,11 +87,12 @@ struct xcresultparser: ParsableCommand {
         writeToStdOut(rslt)
     }
     
-    private func outputJUnitXML(for xcresult: String) throws {
+    private func outputJUnitXML(for xcresult: String,
+                                with format: TestReportFormat) throws {
         guard let junitXML = JunitXML(
             with: URL(fileURLWithPath: xcresult),
             projectRoot: projectRoot ?? "",
-            format: .sonar
+            format: format
         ) else {
             throw ParseError.argumentError
         }
@@ -131,6 +134,8 @@ struct xcresultparser: ParsableCommand {
         case .txt:
             return TextResultFormatter()
         case .cobertura:
+            fallthrough
+        case .junit:
             fallthrough
         case .xml:
             // outputFormatter is not used in case of .xml

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Interpret binary .xcresult files and print summary in different formats:
 - txt
 - colored command line output
 - xml
+- junit
 - cobertura
 - html
 - markdown
@@ -88,8 +89,8 @@ ARGUMENTS:
 OPTIONS:
   -o, --output-format <output-format>
                           The output format. It can be either 'txt', 'cli',
-                          'html', 'md', 'xml', or 'cobertura'. In case of 'xml'
-                          JUnit format for test results and generic format
+                          'html', 'md', 'xml', 'junit', or 'cobertura'. In case of 'xml'
+                          generic format (Sonarqube) for test results and generic format
                           (Sonarqube) for coverage data is used. In the case of
                           'cobertura', --coverage is implied.
   -p, --project-root <project-root>
@@ -140,13 +141,18 @@ Create a single html file with test data
 ### Junit output
 Create an xml file in JUnit format:
 ```
-./xcresultparser -o xml test.xcresult > junit.xml
+./xcresultparser -o junit test.xcresult > junit.xml
 ```
 
 ### Sonarqube output
+Create an xml file in generic test exectuion xml format:
+```
+./xcresultparser -o xml test.xcresult > sonarTestExecution.xml
+```
+
 Create an xml file in generic code coverage xml format:
 ```
-./xcresultparser -c -o xml test.xcresult > sonar.xml
+./xcresultparser -c -o xml test.xcresult > sonarCoverage.xml
 ```
 
 ### Cobertura XML output

--- a/Sources/xcresultparser/OutputFormatting/OutputFormat.swift
+++ b/Sources/xcresultparser/OutputFormatting/OutputFormat.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum OutputFormat: String {
-    case txt, cli, html, xml, cobertura, md
+    case txt, cli, html, xml, junit, cobertura, md
     
     public init(string: String?) {
         if let input = string?.lowercased(),

--- a/Tests/XcresultparserTests/XcresultparserTests.swift
+++ b/Tests/XcresultparserTests/XcresultparserTests.swift
@@ -126,6 +126,8 @@ Summary
         }
 
         XCTAssertTrue(junitXML.xmlString.starts(with: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
+        let dataXML = try! XMLDocument.init(xmlString: junitXML.xmlString, options: [])
+        XCTAssertEqual(dataXML.rootElement()?.name, "testExecutions")
     }
 
     func testJunitXMLJunit() throws {
@@ -141,6 +143,8 @@ Summary
         }
 
         XCTAssertTrue(junitXML.xmlString.starts(with: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"))
+        let dataXML = try! XMLDocument.init(xmlString: junitXML.xmlString, options: [])
+        XCTAssertEqual(dataXML.rootElement()?.name, "testsuites")
     }
 
     func testOutputFormat() {


### PR DESCRIPTION
## Context

Circleci and probably other tools as well need the Junit xml format in order to properly parse test runs.
Support for both the sonar generic test execution format and the Junit XML format were already implemented 👏🏼 

This PR simply adds the option to select the `junit` test report formatter from the cli tool.
Default is still the sonar generic test execution format, the change is non breaking.

## Summary of changes

* Add new `junit` output format
* Improve tests by checking for root element name
* Update docs
* Bump version