### PR TITLE
Output detail from all actions, not just the first; Disambiguate using runDestination

### DIFF
--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -199,6 +199,7 @@ public struct XCResultFormatter {
         }
         let testPlanRunSummaries = testPlanRun.summaries
         let failureSummaries = invocationRecord.issues.testFailureSummaries
+        let runDestination = testAction.runDestination.displayName
         
         for thisSummary in testPlanRunSummaries {
             lines.append(
@@ -206,8 +207,9 @@ public struct XCResultFormatter {
             )
             for thisTestableSummary in thisSummary.testableSummaries {
                 if let targetName = thisTestableSummary.targetName {
+                    let targetConfig = "\(targetName) on '\(runDestination)'"
                     lines.append(
-                        outputFormatter.testConfiguration(targetName)
+                        outputFormatter.testConfiguration(targetConfig)
                     )
                 }
 

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -185,8 +185,7 @@ public struct XCResultFormatter {
     
     private func createTestDetailsString() -> [String] {
         var lines = [String]()
-        let testAction = invocationRecord.actions.first { $0.schemeCommandName == "Test" }
-        if let testAction = testAction {
+        for testAction in invocationRecord.actions where testAction.schemeCommandName == "Test" {
             lines.append(contentsOf: createTestDetailsString(forAction: testAction))
         }
         return lines

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -186,7 +186,15 @@ public struct XCResultFormatter {
     private func createTestDetailsString() -> [String] {
         var lines = [String]()
         let testAction = invocationRecord.actions.first { $0.schemeCommandName == "Test" }
-        guard let testsId = testAction?.actionResult.testsRef?.id,
+        if let testAction = testAction {
+            lines.append(contentsOf: createTestDetailsString(forAction: testAction))
+        }
+        return lines
+    }
+    
+    private func createTestDetailsString(forAction testAction: ActionRecord) -> [String] {
+        var lines = [String]()
+        guard let testsId = testAction.actionResult.testsRef?.id,
               let testPlanRun = resultFile.getTestPlanRunSummaries(id: testsId) else {
             return lines
         }


### PR DESCRIPTION
In our CI environment our xcresult files contain two "Actions" as we test on two distinct devices.

We recently had a case where a PR failed on the second of those devices, but passed on the first. This resulted in the xcresultparser output summary containing "Number of failed tests = 1" but the detail contained no test failures.

This change resolves this by enumerating all actions when generating the detail. To disambiguate, the run destination eg "iPhone 14 Pro" is displayed alongside the target name.

I'm happy to take feedback and evolve this change. I appreciate outputting the run destination is a functional change. I considered making it opt-in behind a cli flag; but also think it's reasonable to display it always.