### PR TITLE
Adds support for Skipped and Expected Failure test statuses

### DIFF
--- a/Sources/xcresultparser/JunitXML.swift
+++ b/Sources/xcresultparser/JunitXML.swift
@@ -207,6 +207,8 @@ public struct JunitXML: XmlSerializable {
                 } else {
                     testcase.addChild(failureWithoutSummary)
                 }
+            } else if thisTest.isSkipped {
+                testcase.addChild(skippedWithoutSummary)
             }
             combined.append(testcase)
         }
@@ -215,6 +217,10 @@ public struct JunitXML: XmlSerializable {
     
     private var failureWithoutSummary: XMLElement {
         return XMLElement(name: "failure")
+    }
+
+    private var skippedWithoutSummary: XMLElement {
+        return XMLElement(name: "skipped")
     }
 }
 

--- a/Sources/xcresultparser/OutputFormatting/Formatters/Markdown/MDResultFormatter.swift
+++ b/Sources/xcresultparser/OutputFormatting/Formatters/Markdown/MDResultFormatter.swift
@@ -11,6 +11,7 @@ public struct MDResultFormatter: XCResultFormatting {
 
     public let testFailIcon = "🔴&nbsp;&nbsp;"
     public let testPassIcon = "🟢&nbsp;&nbsp;"
+    public let testSkipIcon = "⚪️&nbsp;&nbsp;"
 
     public init() { }
 

--- a/Sources/xcresultparser/OutputFormatting/Formatters/XCResultFormatting.swift
+++ b/Sources/xcresultparser/OutputFormatting/Formatters/XCResultFormatting.swift
@@ -26,7 +26,8 @@ public protocol XCResultFormatting {
     func failedTestItem(_ item: String, message: String) -> String
     var testFailIcon: String { get }
     var testPassIcon: String { get }
-    
+    var testSkipIcon: String { get }
+
     func codeCoverageTargetSummary(_ item: String) -> String
     func codeCoverageFileSummary(_ item: String) -> String
     func codeCoverageFunctionSummary(_ items: [String]) -> String
@@ -38,5 +39,8 @@ public extension XCResultFormatting {
     }
     var testPassIcon: String {
         return "✓"
+    }
+    var testSkipIcon: String {
+        return "-"
     }
 }

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -280,7 +280,7 @@ public struct XCResultFormatter {
     
     private func actionTestFileStatusString(for testData: ActionTestMetadata, failureSummaries: [TestFailureIssueSummary]) -> String {
         let duration = numFormatter.unwrappedString(for: testData.duration)
-        let icon = testData.isFailed ? outputFormatter.testFailIcon: outputFormatter.testPassIcon
+        let icon = actionTestFileStatusStringIcon(testData: testData)
         let testTitle = "\(icon) \(testData.name ?? "Missing-Name") (\(duration))"
         let testCaseName = testData.identifier?.replacingOccurrences(of: "/", with: ".") ?? "No-identifier"
         if let summary = failureSummaries.first(where: { $0.testCaseName == testCaseName }) {
@@ -289,7 +289,19 @@ public struct XCResultFormatter {
             return outputFormatter.singleTestItem(testTitle, failed: testData.isFailed)
         }
     }
-    
+
+    private func actionTestFileStatusStringIcon(testData: ActionTestMetadata) -> String {
+        if testData.isSuccessful {
+            return outputFormatter.testPassIcon
+        }
+
+        if testData.isSkipped {
+            return outputFormatter.testSkipIcon
+        }
+
+        return outputFormatter.testFailIcon
+    }
+
     private func actionTestFailureStatusString(with header: String, and failure: TestFailureIssueSummary) -> String {
         return outputFormatter.failedTestItem(header, message: failure.message)
     }
@@ -374,7 +386,15 @@ public struct XCResultFormatter {
 
 extension ActionTestMetadata {
     var isFailed: Bool {
-        return testStatus != "Success"
+        return isSuccessful == false && isSkipped == false
+    }
+
+    var isSuccessful: Bool {
+        return testStatus == "Success" || testStatus == "Expected Failure"
+    }
+
+    var isSkipped: Bool {
+        return testStatus == "Skipped"
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/a7ex/xcresultparser/issues/15

Adjusts the logic for handling test statuses to support all 4 possible values:
- Success
- Failure
- Expected Failure
- Skipped