### PR TITLE
Coverage Converter update

### DIFF
--- a/Sources/xcresultparser/CoberturaCoverageConverter.swift
+++ b/Sources/xcresultparser/CoberturaCoverageConverter.swift
@@ -31,6 +31,68 @@
 import Foundation
 import XCResultKit
 
+enum JSONParseError: Error {
+    case convertError(code: Int, message: String)
+}
+
+// Subrange information struct
+struct Subrange: Codable {
+    let column: Int
+    let executionCount: Int
+    let length: Int
+}
+
+// LineDetail information struct
+struct LineDetail: Codable {
+    let isExecutable: Bool
+    let line: Int
+    let executionCount: Int?
+    let subranges: [Subrange]?
+}
+
+// FileCoverage information struct
+struct FileCoverage: Codable {
+    let files: [String: [LineDetail]]
+
+    // Custom initializer to handle the top-level dictionary
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var filesDict = [String: [LineDetail]]()
+
+        for key in container.allKeys {
+            let keyString = key.stringValue
+            let lineDetails = try container.decode([LineDetail].self, forKey: key)
+            filesDict[keyString] = lineDetails
+        }
+        self.files = filesDict
+    }
+
+    // Custom encoding method to handle the top-level dictionary
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        for (key, value) in files {
+            guard let codingKey = CodingKeys(stringValue: key) else {
+                continue
+            }
+            try container.encode(value, forKey: codingKey)
+        }
+    }
+
+    private struct CodingKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
+        }
+
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+}
+
 public class CoberturaCoverageConverter: CoverageConverter, XmlSerializable {
 
     public var xmlString: String {
@@ -60,44 +122,55 @@ public class CoberturaCoverageConverter: CoverageConverter, XmlSerializable {
         let packagesElement = XMLElement(name: "packages")
         rootElement.addChild(packagesElement)
 
+        // Get the xccov results as a JSON.
+        var arguments = ["xccov", "view"]
+        if resultFile.url.pathExtension == "xcresult" {
+            arguments.append("--archive")
+        }
+        arguments.append("--json")
+        arguments.append(resultFile.url.path)
+        let coverageData = try Shell.execute(program: "/usr/bin/xcrun", with: arguments)
+        let resultsString = String(decoding: coverageData, as: UTF8.self)
+        guard let jsonData = resultsString.data(using: String.Encoding.utf8) else {
+            writeToStdError("Failed to convert to Data")
+            throw JSONParseError.convertError(code: 0, message: "Failed to convert to Data object")
+        }
+        guard let coverageJson = try? JSONDecoder().decode(FileCoverage.self, from: jsonData) else {
+            writeToStdError("Failed to convert to JSON")
+            throw JSONParseError.convertError(code: 0, message: "Failed to convert to JSON Object")
+        }
+
         let fileInfoSemaphore = DispatchSemaphore(value: 1)
         var fileInfo: [FileInfo] = []
-        
-        // since we need to invoke xccov for each file, it takes pretty much time
-        // so we invoke it in parallel on 8 threads, that speeds up things considerably
         let queue = OperationQueue()
-        queue.maxConcurrentOperationCount = 8 //Deadlock if this is = 1
+        queue.maxConcurrentOperationCount = ProcessInfo.processInfo.processorCount //Deadlock if this is = 1
         queue.qualityOfService = .userInitiated
+        for (fileName, value) in coverageJson.files {
+            let op = BlockOperation {
+                var fileLines = [LineInfo]() // This will store information about each line.
 
-        var processedFiles = [String]()
-        for target in codeCoverage.targets {
-            if !coverageTargets.isEmpty {
-                guard coverageTargets.contains(target.name) else { continue }
-            }
-            for codeCovFile in target.files {
-                let file = codeCovFile.path
-                guard !processedFiles.contains(file) else { continue }
-                processedFiles.append(file)
-                guard !file.isEmpty else { continue }
-                if !quiet {
-                    writeToStdError("Coverage for: \(file)\n")
-                }
-                let op = BlockOperation { [self] in
-                    do {
-                        let coverage = try fileCoverage(for: file, relativeTo: projectRoot)
-                        fileInfoSemaphore.wait()
-                        fileInfo.append(coverage)
-                        fileInfoSemaphore.signal()
-                    } catch {
-                        writeToStdErrorLn(error.localizedDescription)
+                for lineData in value {
+                    let lineNum = lineData.line
+                    var covered = lineData.executionCount
+                    if covered != nil {
+                        // If the line coverage count is a MAX_INT, just set it to 1
+                        if covered == Int.max {
+                            covered = 1
+                        }
+                        let line = LineInfo(lineNumber: String(lineNum), coverage: covered!)
+                        fileLines.append(line)
                     }
                 }
-                queue.addOperation(op)
+
+                let fileInfoInst = FileInfo(path: self.relativePath(for: fileName, relativeTo: self.projectRoot), lines: fileLines)
+                fileInfoSemaphore.wait()
+                fileInfo.append(fileInfoInst)
+                fileInfoSemaphore.signal()
             }
+            queue.addOperation(op)
         }
         // This will block until all our operation have compleated (or been canceled)
         queue.waitUntilAllOperationsAreFinished()
-        
         // Sort files to avoid duplicated packages
         fileInfo.sort { $0.path > $1.path }
         


### PR DESCRIPTION
This change was brought about by a necessity to optimize how the coverage for each file was generated. On my machine, running the tool for a large xcresult file would take a long time to complete (roughly 2-2.5 minutes) and would cause a significant draw of CPU as multiple instances of xccov were being run. 

I've attempted to improve the performance by instead making one call to xccov and generating a JSON report for the whole xcresult file and then iterate over the keys in parallel. This brings the time for running the tool against the same file from 2 minutes to 4 seconds. 

This is my first attempt at writing real Swift, so feel free to tear this apart with feedback! Appreciate all the amazing work that has gone into this project! Thanks in advance!