### PR TITLE
Fix cobertura number of hits to detect multiple digit executions

### DIFF
--- a/Sources/xcresultparser/CoverageConverter.swift
+++ b/Sources/xcresultparser/CoverageConverter.swift
@@ -45,7 +45,7 @@ public class CoverageConverter {
 
         self.coverageTargets = record.targets(filteredBy: coverageTargets)
         
-        let pattern = #"(\d+):\s*(\d)"#
+        let pattern = #"(\d+):\s*(\d+)"#
         coverageRegexp = try? NSRegularExpression(pattern: pattern, options: .anchorsMatchLines)
     }
     

--- a/Tests/XcresultparserTests/TestAssets/cobertura.xml
+++ b/Tests/XcresultparserTests/TestAssets/cobertura.xml
@@ -225,7 +225,7 @@
                         <line number="19" branch="false" hits="3"/>
                         <line number="20" branch="false" hits="3"/>
                         <line number="21" branch="false" hits="3"/>
-                        <line number="22" branch="false" hits="1"/>
+                        <line number="22" branch="false" hits="18"/>
                         <line number="23" branch="false" hits="3"/>
                         <line number="24" branch="false" hits="3"/>
                         <line number="37" branch="false" hits="3"/>
@@ -416,13 +416,13 @@
                         <line number="241" branch="false" hits="3"/>
                         <line number="242" branch="false" hits="3"/>
                         <line number="243" branch="false" hits="9"/>
-                        <line number="244" branch="false" hits="2"/>
-                        <line number="245" branch="false" hits="2"/>
-                        <line number="246" branch="false" hits="2"/>
-                        <line number="247" branch="false" hits="2"/>
-                        <line number="248" branch="false" hits="2"/>
-                        <line number="249" branch="false" hits="2"/>
-                        <line number="250" branch="false" hits="2"/>
+                        <line number="244" branch="false" hits="21"/>
+                        <line number="245" branch="false" hits="21"/>
+                        <line number="246" branch="false" hits="21"/>
+                        <line number="247" branch="false" hits="21"/>
+                        <line number="248" branch="false" hits="21"/>
+                        <line number="249" branch="false" hits="21"/>
+                        <line number="250" branch="false" hits="21"/>
                         <line number="251" branch="false" hits="9"/>
                         <line number="252" branch="false" hits="3"/>
                         <line number="253" branch="false" hits="3"/>
@@ -430,16 +430,16 @@
                         <line number="255" branch="false" hits="9"/>
                         <line number="256" branch="false" hits="9"/>
                         <line number="257" branch="false" hits="9"/>
-                        <line number="259" branch="false" hits="2"/>
-                        <line number="260" branch="false" hits="2"/>
-                        <line number="261" branch="false" hits="2"/>
-                        <line number="262" branch="false" hits="2"/>
-                        <line number="263" branch="false" hits="2"/>
-                        <line number="264" branch="false" hits="2"/>
+                        <line number="259" branch="false" hits="21"/>
+                        <line number="260" branch="false" hits="21"/>
+                        <line number="261" branch="false" hits="21"/>
+                        <line number="262" branch="false" hits="21"/>
+                        <line number="263" branch="false" hits="21"/>
+                        <line number="264" branch="false" hits="21"/>
                         <line number="265" branch="false" hits="3"/>
-                        <line number="266" branch="false" hits="1"/>
-                        <line number="267" branch="false" hits="1"/>
-                        <line number="268" branch="false" hits="1"/>
+                        <line number="266" branch="false" hits="18"/>
+                        <line number="267" branch="false" hits="18"/>
+                        <line number="268" branch="false" hits="18"/>
                         <line number="269" branch="false" hits="0"/>
                         <line number="271" branch="false" hits="3"/>
                         <line number="272" branch="false" hits="3"/>
@@ -520,15 +520,15 @@
                         <line number="348" branch="false" hits="0"/>
                         <line number="349" branch="false" hits="0"/>
                         <line number="350" branch="false" hits="0"/>
-                        <line number="354" branch="false" hits="9"/>
-                        <line number="355" branch="false" hits="9"/>
-                        <line number="356" branch="false" hits="9"/>
-                        <line number="360" branch="false" hits="1"/>
-                        <line number="361" branch="false" hits="1"/>
-                        <line number="362" branch="false" hits="1"/>
-                        <line number="366" branch="false" hits="4"/>
-                        <line number="367" branch="false" hits="4"/>
-                        <line number="368" branch="false" hits="4"/>
+                        <line number="354" branch="false" hits="93"/>
+                        <line number="355" branch="false" hits="93"/>
+                        <line number="356" branch="false" hits="93"/>
+                        <line number="360" branch="false" hits="15"/>
+                        <line number="361" branch="false" hits="15"/>
+                        <line number="362" branch="false" hits="15"/>
+                        <line number="366" branch="false" hits="48"/>
+                        <line number="367" branch="false" hits="48"/>
+                        <line number="368" branch="false" hits="48"/>
                         <line number="372" branch="false" hits="0"/>
                         <line number="373" branch="false" hits="0"/>
                         <line number="374" branch="false" hits="0"/>
@@ -543,8 +543,8 @@
                         <line number="383" branch="false" hits="0"/>
                         <line number="384" branch="false" hits="0"/>
                         <line number="388" branch="false" hits="9"/>
-                        <line number="389" branch="false" hits="1"/>
-                        <line number="390" branch="false" hits="1"/>
+                        <line number="389" branch="false" hits="12"/>
+                        <line number="390" branch="false" hits="12"/>
                         <line number="391" branch="false" hits="6"/>
                         <line number="392" branch="false" hits="6"/>
                         <line number="393" branch="false" hits="6"/>
@@ -668,9 +668,9 @@
                         <line number="36" branch="false" hits="3"/>
                         <line number="37" branch="false" hits="3"/>
                         <line number="38" branch="false" hits="3"/>
-                        <line number="39" branch="false" hits="1"/>
-                        <line number="40" branch="false" hits="1"/>
-                        <line number="41" branch="false" hits="1"/>
+                        <line number="39" branch="false" hits="18"/>
+                        <line number="40" branch="false" hits="18"/>
+                        <line number="41" branch="false" hits="18"/>
                     </lines>
                 </class>
             </classes>
@@ -896,13 +896,13 @@
                         <line number="110" branch="false" hits="3"/>
                         <line number="111" branch="false" hits="3"/>
                         <line number="112" branch="false" hits="3"/>
-                        <line number="114" branch="false" hits="1"/>
-                        <line number="115" branch="false" hits="1"/>
-                        <line number="116" branch="false" hits="1"/>
-                        <line number="117" branch="false" hits="1"/>
-                        <line number="118" branch="false" hits="1"/>
-                        <line number="119" branch="false" hits="1"/>
-                        <line number="120" branch="false" hits="1"/>
+                        <line number="114" branch="false" hits="12"/>
+                        <line number="115" branch="false" hits="12"/>
+                        <line number="116" branch="false" hits="12"/>
+                        <line number="117" branch="false" hits="10"/>
+                        <line number="118" branch="false" hits="12"/>
+                        <line number="119" branch="false" hits="12"/>
+                        <line number="120" branch="false" hits="12"/>
                         <line number="122" branch="false" hits="3"/>
                         <line number="123" branch="false" hits="3"/>
                         <line number="124" branch="false" hits="3"/>
@@ -1193,7 +1193,7 @@
                         <line number="139" branch="false" hits="2"/>
                         <line number="140" branch="false" hits="2"/>
                         <line number="141" branch="false" hits="2"/>
-                        <line number="142" branch="false" hits="1"/>
+                        <line number="142" branch="false" hits="14"/>
                         <line number="143" branch="false" hits="2"/>
                         <line number="144" branch="false" hits="2"/>
                         <line number="145" branch="false" hits="2"/>
@@ -1202,7 +1202,7 @@
                         <line number="148" branch="false" hits="2"/>
                         <line number="149" branch="false" hits="2"/>
                         <line number="150" branch="false" hits="2"/>
-                        <line number="151" branch="false" hits="1"/>
+                        <line number="151" branch="false" hits="14"/>
                         <line number="152" branch="false" hits="2"/>
                         <line number="153" branch="false" hits="2"/>
                         <line number="154" branch="false" hits="0"/>
@@ -1227,51 +1227,51 @@
                         <line number="179" branch="false" hits="0"/>
                         <line number="181" branch="false" hits="4"/>
                         <line number="182" branch="false" hits="4"/>
-                        <line number="183" branch="false" hits="2"/>
-                        <line number="184" branch="false" hits="2"/>
-                        <line number="185" branch="false" hits="2"/>
+                        <line number="183" branch="false" hits="28"/>
+                        <line number="184" branch="false" hits="28"/>
+                        <line number="185" branch="false" hits="28"/>
                         <line number="186" branch="false" hits="4"/>
                         <line number="187" branch="false" hits="4"/>
                         <line number="188" branch="false" hits="4"/>
                         <line number="189" branch="false" hits="0"/>
                         <line number="190" branch="false" hits="4"/>
-                        <line number="191" branch="false" hits="2"/>
-                        <line number="192" branch="false" hits="2"/>
-                        <line number="193" branch="false" hits="2"/>
+                        <line number="191" branch="false" hits="28"/>
+                        <line number="192" branch="false" hits="28"/>
+                        <line number="193" branch="false" hits="28"/>
                         <line number="194" branch="false" hits="4"/>
                         <line number="195" branch="false" hits="4"/>
                         <line number="197" branch="false" hits="0"/>
                         <line number="198" branch="false" hits="0"/>
                         <line number="199" branch="false" hits="0"/>
-                        <line number="203" branch="false" hits="1"/>
-                        <line number="204" branch="false" hits="1"/>
-                        <line number="205" branch="false" hits="1"/>
-                        <line number="206" branch="false" hits="1"/>
-                        <line number="207" branch="false" hits="1"/>
-                        <line number="211" branch="false" hits="2"/>
-                        <line number="212" branch="false" hits="2"/>
-                        <line number="213" branch="false" hits="2"/>
-                        <line number="214" branch="false" hits="2"/>
-                        <line number="215" branch="false" hits="2"/>
-                        <line number="216" branch="false" hits="2"/>
-                        <line number="217" branch="false" hits="2"/>
-                        <line number="218" branch="false" hits="1"/>
-                        <line number="219" branch="false" hits="2"/>
-                        <line number="220" branch="false" hits="1"/>
-                        <line number="221" branch="false" hits="2"/>
-                        <line number="222" branch="false" hits="2"/>
-                        <line number="223" branch="false" hits="2"/>
-                        <line number="224" branch="false" hits="2"/>
-                        <line number="225" branch="false" hits="2"/>
-                        <line number="226" branch="false" hits="2"/>
-                        <line number="227" branch="false" hits="1"/>
-                        <line number="228" branch="false" hits="2"/>
-                        <line number="229" branch="false" hits="2"/>
-                        <line number="230" branch="false" hits="2"/>
-                        <line number="231" branch="false" hits="2"/>
-                        <line number="240" branch="false" hits="1"/>
-                        <line number="241" branch="false" hits="1"/>
-                        <line number="242" branch="false" hits="1"/>
+                        <line number="203" branch="false" hits="103"/>
+                        <line number="204" branch="false" hits="103"/>
+                        <line number="205" branch="false" hits="103"/>
+                        <line number="206" branch="false" hits="103"/>
+                        <line number="207" branch="false" hits="103"/>
+                        <line number="211" branch="false" hits="28"/>
+                        <line number="212" branch="false" hits="28"/>
+                        <line number="213" branch="false" hits="28"/>
+                        <line number="214" branch="false" hits="28"/>
+                        <line number="215" branch="false" hits="28"/>
+                        <line number="216" branch="false" hits="28"/>
+                        <line number="217" branch="false" hits="28"/>
+                        <line number="218" branch="false" hits="14"/>
+                        <line number="219" branch="false" hits="28"/>
+                        <line number="220" branch="false" hits="14"/>
+                        <line number="221" branch="false" hits="28"/>
+                        <line number="222" branch="false" hits="28"/>
+                        <line number="223" branch="false" hits="28"/>
+                        <line number="224" branch="false" hits="28"/>
+                        <line number="225" branch="false" hits="28"/>
+                        <line number="226" branch="false" hits="28"/>
+                        <line number="227" branch="false" hits="14"/>
+                        <line number="228" branch="false" hits="28"/>
+                        <line number="229" branch="false" hits="28"/>
+                        <line number="230" branch="false" hits="28"/>
+                        <line number="231" branch="false" hits="28"/>
+                        <line number="240" branch="false" hits="14"/>
+                        <line number="241" branch="false" hits="14"/>
+                        <line number="242" branch="false" hits="14"/>
                         <line number="244" branch="false" hits="2"/>
                         <line number="245" branch="false" hits="2"/>
                         <line number="246" branch="false" hits="2"/>
@@ -1324,9 +1324,9 @@
                         <line number="297" branch="false" hits="4"/>
                         <line number="298" branch="false" hits="2"/>
                         <line number="299" branch="false" hits="2"/>
-                        <line number="300" branch="false" hits="1"/>
-                        <line number="301" branch="false" hits="1"/>
-                        <line number="302" branch="false" hits="1"/>
+                        <line number="300" branch="false" hits="14"/>
+                        <line number="301" branch="false" hits="14"/>
+                        <line number="302" branch="false" hits="14"/>
                         <line number="303" branch="false" hits="4"/>
                         <line number="307" branch="false" hits="4"/>
                         <line number="308" branch="false" hits="4"/>
@@ -1335,7 +1335,7 @@
                         <line number="311" branch="false" hits="4"/>
                         <line number="312" branch="false" hits="4"/>
                         <line number="313" branch="false" hits="4"/>
-                        <line number="314" branch="false" hits="1"/>
+                        <line number="314" branch="false" hits="12"/>
                         <line number="315" branch="false" hits="4"/>
                         <line number="316" branch="false" hits="4"/>
                         <line number="317" branch="false" hits="4"/>
@@ -1367,9 +1367,9 @@
                         <line number="344" branch="false" hits="0"/>
                         <line number="345" branch="false" hits="0"/>
                         <line number="346" branch="false" hits="0"/>
-                        <line number="350" branch="false" hits="1"/>
-                        <line number="351" branch="false" hits="1"/>
-                        <line number="352" branch="false" hits="1"/>
+                        <line number="350" branch="false" hits="14"/>
+                        <line number="351" branch="false" hits="14"/>
+                        <line number="352" branch="false" hits="14"/>
                         <line number="356" branch="false" hits="4"/>
                         <line number="357" branch="false" hits="4"/>
                         <line number="358" branch="false" hits="4"/>


### PR DESCRIPTION
Fixes #26 

Adjusts the CoverageConverter's regex pattern to support lines that have been executed more than 9 times.