### PR TITLE
Control coverage report verborsity

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcresultparser.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcresultparser.xcscheme
@@ -81,6 +81,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--cov-fmt methods"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--target-info"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcresultparser.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcresultparser.xcscheme
@@ -81,7 +81,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--cov-fmt methods"
+            argument = "--coverage-report-format targets"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.6.1 - 2024-05-19
+### CHANGES:
+Adds support for configurying the coverage report format
+
 ## Version 1.6.0 - 2024-05-19
 ### CHANGES:
 Updated the tool for Xcode 15 xccov tool. ATTENTION: use version 1.5.2 of this tool, if you are still using Xcode 14. Coverage won't work otherwise.

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -9,14 +9,14 @@ import ArgumentParser
 import Foundation
 import XcresultparserLib
 
-private let marketingVersion = "1.6.0"
+private let marketingVersion = "1.6.1"
 
 struct xcresultparser: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "xcresultparser \(marketingVersion)\nInterpret binary .xcresult files and print summary in different formats: txt, xml, html or colored cli output."
     )
     
-    @Option(name: .customLong("cov-fmt"), help: "The coverage report format. The Default is 'methods', It can either be 'totals', 'targets', 'classes' or 'methods'. totals: only a total coverage percentage is shown, 'targets': totals and coverage per target shown, 'classes': targets with coverage per class shown & 'methods': classes with coverage per method shown")
+    @Option(name: .long, help: "The coverage report format. The Default is 'methods', It can either be 'totals', 'targets', 'classes' or 'methods'")
     var coverageReportFormat: String?
 
     @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', 'junit', 'cobertura', 'warnings', 'errors' and 'warnings-and-errors'. In case of 'xml' sonar generic format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage is implied.")

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -15,6 +15,9 @@ struct xcresultparser: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "xcresultparser \(marketingVersion)\nInterpret binary .xcresult files and print summary in different formats: txt, xml, html or colored cli output."
     )
+    
+    @Option(name: .customLong("cov-fmt"), help: "The coverage report format. The Default is 'methods', It can either be 'totals', 'targets', 'classes' or 'methods'. totals: only a total coverage percentage is shown, 'targets': totals and coverage per target shown, 'classes': targets with coverage per class shown & 'methods': classes with coverage per method shown")
+    var coverageReportFormat: String?
 
     @Option(name: .shortAndLong, help: "The output format. It can be either 'txt', 'cli', 'html', 'md', 'xml', 'junit', 'cobertura', 'warnings', 'errors' and 'warnings-and-errors'. In case of 'xml' sonar generic format for test results and generic format (Sonarqube) for coverage data is used. In the case of 'cobertura', --coverage is implied.")
     var outputFormat: String?
@@ -144,7 +147,8 @@ struct xcresultparser: ParsableCommand {
             formatter: outputFormatter,
             coverageTargets: coverageTargets,
             failedTestsOnly: failedTestsOnly == 1,
-            summaryFields: summaryFields ?? "errors|warnings|analyzerWarnings|tests|failed|skipped"
+            summaryFields: summaryFields ?? "errors|warnings|analyzerWarnings|tests|failed|skipped",
+            coverageReportFormat: CoverageReportFormat(string: coverageReportFormat)
         ) else {
             throw ParseError.argumentError
         }

--- a/Sources/xcresultparser/OutputFormatting/CoverageReportFormat.swift
+++ b/Sources/xcresultparser/OutputFormatting/CoverageReportFormat.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//
+//
+//  Created by nkokhelo mhlongo on 2024/05/31.
+//
+
+public enum CoverageReportFormat: String {
+    case methods, classes, targets, totals
+    public init(string: String?) {
+        if let input = string?.lowercased(),
+           let fmt = CoverageReportFormat(rawValue: input) {
+            self = fmt
+        } else {
+            self = .methods
+        }
+    }
+}

--- a/Sources/xcresultparser/OutputFormatting/CoverageReportFormat.swift
+++ b/Sources/xcresultparser/OutputFormatting/CoverageReportFormat.swift
@@ -1,6 +1,5 @@
 //
-//  File.swift
-//
+//  CoverageReportFormat.swift
 //
 //  Created by nkokhelo mhlongo on 2024/05/31.
 //

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -12,7 +12,7 @@ public struct XCResultFormatter {
     private enum SummaryField: String {
         case errors, warnings, analyzerWarnings, tests, failed, skipped
     }
-    
+
     private struct SummaryFields {
         let enabledFields: Set<SummaryField>
         init(specifiers: String) {
@@ -23,9 +23,9 @@ public struct XCResultFormatter {
             )
         }
     }
-    
+
     // MARK: - Properties
-    
+
     private let resultFile: XCResultFile
     private let invocationRecord: ActionsInvocationRecord
     private let codeCoverage: CodeCoverage?
@@ -34,21 +34,21 @@ public struct XCResultFormatter {
     private let failedTestsOnly: Bool
     private let summaryFields: SummaryFields
     private let coverageReportFormat: CoverageReportFormat
-    
+
     private var numFormatter: NumberFormatter = {
         let numFormatter = NumberFormatter()
         numFormatter.maximumFractionDigits = 4
         return numFormatter
     }()
-    
+
     private var percentFormatter: NumberFormatter = {
         let numFormatter = NumberFormatter()
         numFormatter.maximumFractionDigits = 1
         return numFormatter
     }()
-    
+
     // MARK: - Initializer
-    
+
     public init?(
         with url: URL,
         formatter: XCResultFormatting,
@@ -68,19 +68,19 @@ public struct XCResultFormatter {
         self.failedTestsOnly = failedTestsOnly
         self.summaryFields = SummaryFields(specifiers: summaryFields)
         self.coverageReportFormat = coverageReportFormat
-        
+
         // if let logsId = invocationRecord?.actions.last?.actionResult.logRef?.id {
         //    let testLogs = resultFile.getLogs(id: logsId)
         // }
         //
         //        let testSummary = resultFile.getActionTestSummary(id: "xxx")
-        
+
         // let payload = resultFile.getPayload(id: "123")
         // let exportedPath = resultFile.exportPayload(id: "123")
     }
-    
+
     // MARK: - Public API
-    
+
     public var summary: String {
         if outputFormatter is MDResultFormatter {
             return createSummaryInOneLine()
@@ -88,41 +88,41 @@ public struct XCResultFormatter {
             return createSummary().joined(separator: "\n")
         }
     }
-    
+
     public var testDetails: String {
         return createTestDetailsString().joined(separator: "\n")
     }
-    
+
     public var divider: String {
         return outputFormatter.divider
     }
-    
+
     public func documentPrefix(title: String) -> String {
         return outputFormatter.documentPrefix(title: title)
     }
-    
+
     public var documentSuffix: String {
         return outputFormatter.documentSuffix
     }
-    
+
     public var coverageDetails: String {
         return createCoverageReport().joined(separator: "\n")
     }
-    
+
     // MARK: - Private API
-    
+
     private func createSummary() -> [String] {
         let metrics = invocationRecord.metrics
-        
+
         let analyzerWarningCount = metrics.analyzerWarningCount ?? 0
         let errorCount = metrics.errorCount ?? 0
         let testsCount = metrics.testsCount ?? 0
         let testsFailedCount = metrics.testsFailedCount ?? 0
         let warningCount = metrics.warningCount ?? 0
         let testsSkippedCount = metrics.testsSkippedCount ?? 0
-        
+
         var lines = [String]()
-        
+
         lines.append(
             outputFormatter.testConfiguration("Summary")
         )
@@ -170,17 +170,17 @@ public struct XCResultFormatter {
         }
         return lines
     }
-    
+
     private func createSummaryInOneLine() -> String {
         let metrics = invocationRecord.metrics
-        
+
         let analyzerWarningCount = metrics.analyzerWarningCount ?? 0
         let errorCount = metrics.errorCount ?? 0
         let testsCount = metrics.testsCount ?? 0
         let testsFailedCount = metrics.testsFailedCount ?? 0
         let warningCount = metrics.warningCount ?? 0
         let testsSkippedCount = metrics.testsSkippedCount ?? 0
-        
+
         var summary = ""
         if summaryFields.enabledFields.contains(.errors) {
             summary += "Errors: \(errorCount)"
@@ -202,7 +202,7 @@ public struct XCResultFormatter {
         }
         return summary
     }
-    
+
     private func createTestDetailsString() -> [String] {
         var lines = [String]()
         for testAction in invocationRecord.actions where testAction.schemeCommandName == "Test" {
@@ -210,7 +210,7 @@ public struct XCResultFormatter {
         }
         return lines
     }
-    
+
     private func createTestDetailsString(forAction testAction: ActionRecord) -> [String] {
         var lines = [String]()
         guard let testsId = testAction.actionResult.testsRef?.id,
@@ -220,7 +220,7 @@ public struct XCResultFormatter {
         let testPlanRunSummaries = testPlanRun.summaries
         let failureSummaries = invocationRecord.issues.testFailureSummaries
         let runDestination = testAction.runDestination.displayName
-        
+
         for thisSummary in testPlanRunSummaries {
             lines.append(
                 outputFormatter.testConfiguration(thisSummary.name ?? "No-name")
@@ -232,7 +232,7 @@ public struct XCResultFormatter {
                         outputFormatter.testConfiguration(targetConfig)
                     )
                 }
-                
+
                 if failedTestsOnly,
                    outputFormatter is CLIResultFormatter,
                    thisTestableSummary.tests.allSatisfy({ $0.hasNoFailedTests }) {
@@ -242,7 +242,7 @@ public struct XCResultFormatter {
                         lines += createTestSummaryInfo(thisTest, level: 0, failureSummaries: failureSummaries)
                     }
                 }
-                
+
                 lines.append(
                     outputFormatter.divider
                 )
@@ -250,7 +250,7 @@ public struct XCResultFormatter {
         }
         return lines
     }
-    
+
     private func createTestSummaryInfo(
         _ group: ActionTestSummaryGroup,
         level: Int,
@@ -262,7 +262,7 @@ public struct XCResultFormatter {
             return lines
         }
         let header = "\(group.nameString) (\(numFormatter.unwrappedString(for: group.duration)))"
-        
+
         switch level {
         case 0:
             break
@@ -301,7 +301,7 @@ public struct XCResultFormatter {
         }
         return lines
     }
-    
+
     private func actionTestFileStatusString(
         for testData: ActionTestMetadata,
         failureSummaries: [TestFailureIssueSummary]
@@ -316,26 +316,26 @@ public struct XCResultFormatter {
             return outputFormatter.singleTestItem(testTitle, failed: testData.isFailed)
         }
     }
-    
+
     private func actionTestFileStatusStringIcon(testData: ActionTestMetadata) -> String {
         if testData.isSuccessful {
             return outputFormatter.testPassIcon
         }
-        
+
         if testData.isSkipped {
             return outputFormatter.testSkipIcon
         }
-        
+
         return outputFormatter.testFailIcon
     }
-    
+
     private func actionTestFailureStatusString(
         with header: String,
         and failure: TestFailureIssueSummary
     ) -> String {
         return outputFormatter.failedTestItem(header, message: failure.message)
     }
-    
+
     private func createCoverageReport() -> [String] {
         var lines = [String]()
         lines.append(
@@ -357,7 +357,7 @@ public struct XCResultFormatter {
                         "\(target.name): \(covPercent)% (\(target.coveredLines)/\(target.executableLines))"
                     )
                 )
-                
+
                 if(coverageReportFormat != .targets) {
                     if !outputFormatter.accordionOpenTag.isEmpty {
                         lines.append(
@@ -430,11 +430,11 @@ extension ActionTestMetadata {
     var isFailed: Bool {
         return isSuccessful == false && isSkipped == false
     }
-    
+
     var isSuccessful: Bool {
         return testStatus == "Success" || testStatus == "Expected Failure"
     }
-    
+
     var isSkipped: Bool {
         return testStatus == "Skipped"
     }
@@ -482,7 +482,7 @@ private extension ActionTestSummaryGroup {
         }
         return false
     }
-    
+
     var hasNoFailedTests: Bool {
         return !hasFailedTests
     }

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -487,3 +487,4 @@ private extension ActionTestSummaryGroup {
         return !hasFailedTests
     }
 }
+

--- a/Sources/xcresultparser/XCResultFormatter.swift
+++ b/Sources/xcresultparser/XCResultFormatter.swift
@@ -357,7 +357,6 @@ public struct XCResultFormatter {
                         "\(target.name): \(covPercent)% (\(target.coveredLines)/\(target.executableLines))"
                     )
                 )
-
                 if(coverageReportFormat != .targets) {
                     if !outputFormatter.accordionOpenTag.isEmpty {
                         lines.append(


### PR DESCRIPTION
Added the ability to control how much detailed is the coverage report.

| --coverage-report-format = | totals | targets | classes | methods |
| ---------------------------- | ----- | ------- | -------- | --------- |
| description | will only show the total coverage | will show total coverage and coverage per target | will show class coverage under each target | will show full detailed coverage including the function coverage and its call count |
| example | <img width="426" alt="Screenshot 2024-05-31 at 15 42 34" src="https://github.com/a7ex/xcresultparser/assets/10595966/c851f0a1-eb50-4a9d-a4e6-f0a46567e386"> | <img width="426" alt="Screenshot 2024-05-31 at 15 42 51" src="https://github.com/a7ex/xcresultparser/assets/10595966/a33607b0-566c-40f1-961a-cd6ca5ee9c0b"> | <img width="426" alt="Screenshot 2024-05-31 at 15 43 09" src="https://github.com/a7ex/xcresultparser/assets/10595966/ad720bd5-8aa6-43f8-875b-bdb2914988b6"> | <img width="683" alt="Screenshot 2024-05-31 at 15 43 24" src="https://github.com/a7ex/xcresultparser/assets/10595966/814efc0b-492e-4f96-b928-b383548418a8"> |


