### PR TITLE
Changed the Junit xml slightly in order to be compatible with Jenkins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version 1.6.5 - 2024-07-04
+### CHANGES:
+Changed the Junit xml slightly in order to be compatible with Jenkins plugin
+
+It looks like the Jenkins plugin (https://plugins.jenkins.io/xunit/) expects:
+only 3 decimal places after the . in the time attribute
+an errors attribute, even if errors=0 on the testsuite
+
 ## Version 1.6.4 - 2024-06-16
 ### CHANGES:
 removed swiftlint plugin from Package.swift file, as it seems to not work with commandline tools?

--- a/CommandlineTool/main.swift
+++ b/CommandlineTool/main.swift
@@ -9,7 +9,7 @@ import ArgumentParser
 import Foundation
 import XcresultparserLib
 
-private let marketingVersion = "1.6.4"
+private let marketingVersion = "1.6.5"
 
 struct xcresultparser: ParsableCommand {
     static let configuration = CommandConfiguration(

--- a/Sources/xcresultparser/JunitXML.swift
+++ b/Sources/xcresultparser/JunitXML.swift
@@ -47,7 +47,7 @@ public struct JunitXML: XmlSerializable {
 
     private var numFormatter: NumberFormatter = {
         let numFormatter = NumberFormatter()
-        numFormatter.maximumFractionDigits = 4
+        numFormatter.maximumFractionDigits = 3
         numFormatter.locale = Locale(identifier: "en_US")
         return numFormatter
     }()
@@ -93,6 +93,7 @@ public struct JunitXML: XmlSerializable {
             testsuites.addAttribute(name: "tests", stringValue: String(testsCount))
             let testsFailedCount = metrics.testsFailedCount ?? 0
             testsuites.addAttribute(name: "failures", stringValue: String(testsFailedCount))
+            testsuites.addAttribute(name: "errors", stringValue: "0") // apparently Jenkins needs this?!
         }
 
         let testActions = invocationRecord.actions.filter { $0.schemeCommandName == "Test" }
@@ -300,6 +301,7 @@ private extension ActionTestSummaryGroup {
         let stats = statistics
         testsuite.addAttribute(name: "tests", stringValue: String(stats.tests))
         testsuite.addAttribute(name: "failures", stringValue: String(stats.failures))
+        testsuite.addAttribute(name: "errors", stringValue: "0") // apparently Jenkins needs this?!
         testsuite.addAttribute(name: "time", stringValue: numFormatter.unwrappedString(for: duration))
         return testsuite
     }
@@ -332,7 +334,6 @@ private extension ActionTestSummaryGroup {
             }
             return result
         } catch {
-            print("Error: \(error)")
             return identifierString
         }
     }

--- a/Tests/XcresultparserTests/TestAssets/junit.xml
+++ b/Tests/XcresultparserTests/TestAssets/junit.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="7" failures="1" time="9.01">
-  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" time="4.3274">
-    <testcase name="testCLIResultFormatter()" time="0.3073" classname="XcresultparserTests"/>
+<testsuites tests="7" failures="1" errors="0" time="9.01">
+  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
+    <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
       <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
-    <testcase name="testHTMLResultFormatter()" time="0.3317" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLJunit()" time="0.2559" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLSonar()" time="0.2664" classname="XcresultparserTests"/>
-    <testcase name="testOutputFormat()" time="0.0008" classname="XcresultparserTests"/>
-    <testcase name="testTextResultFormatter()" time="0.3451" classname="XcresultparserTests"/>
+    <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLSonar()" time="0.266" classname="XcresultparserTests"/>
+    <testcase name="testOutputFormat()" time="0.001" classname="XcresultparserTests"/>
+    <testcase name="testTextResultFormatter()" time="0.345" classname="XcresultparserTests"/>
   </testsuite>
 </testsuites>

--- a/Tests/XcresultparserTests/TestAssets/junit_merged.xml
+++ b/Tests/XcresultparserTests/TestAssets/junit_merged.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="7" failures="1" time="18.02">
-  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" time="4.3274">
-    <testcase name="testCLIResultFormatter()" time="0.3073" classname="XcresultparserTests"/>
+<testsuites tests="7" failures="1" errors="0" time="18.02">
+  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
+    <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
       <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
-    <testcase name="testHTMLResultFormatter()" time="0.3317" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLJunit()" time="0.2559" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLSonar()" time="0.2664" classname="XcresultparserTests"/>
-    <testcase name="testOutputFormat()" time="0.0008" classname="XcresultparserTests"/>
-    <testcase name="testTextResultFormatter()" time="0.3451" classname="XcresultparserTests"/>
+    <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLSonar()" time="0.266" classname="XcresultparserTests"/>
+    <testcase name="testOutputFormat()" time="0.001" classname="XcresultparserTests"/>
+    <testcase name="testTextResultFormatter()" time="0.345" classname="XcresultparserTests"/>
   </testsuite>
-  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" time="4.3274">
-    <testcase name="testCLIResultFormatter()" time="0.3073" classname="XcresultparserTests"/>
+  <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
+    <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
       <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
-    <testcase name="testHTMLResultFormatter()" time="0.3317" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLJunit()" time="0.2559" classname="XcresultparserTests"/>
-    <testcase name="testJunitXMLSonar()" time="0.2664" classname="XcresultparserTests"/>
-    <testcase name="testOutputFormat()" time="0.0008" classname="XcresultparserTests"/>
-    <testcase name="testTextResultFormatter()" time="0.3451" classname="XcresultparserTests"/>
+    <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>
+    <testcase name="testJunitXMLSonar()" time="0.266" classname="XcresultparserTests"/>
+    <testcase name="testOutputFormat()" time="0.001" classname="XcresultparserTests"/>
+    <testcase name="testTextResultFormatter()" time="0.345" classname="XcresultparserTests"/>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
… plugin

It looks like the Jenkins plugin (https://plugins.jenkins.io/xunit/) expects: only 3 decimal places after the . in the time attribute an errors attribute, even if errors=0 on the testsuite