### PR TITLE
fix: support Xcode 15 Swift version 5.9

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "54446e8a2617deadae3d77bc72533cbf1e25290c734ad296ddfdd7c2b8a1e9ac",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -20,5 +19,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This to be more compatible with the minimum supported Xcode 15.0 version in brew context.