### PR TITLE
Fix short message and type not populated for junit output

### DIFF
--- a/Sources/xcresultparser/JunitXML.swift
+++ b/Sources/xcresultparser/JunitXML.swift
@@ -485,11 +485,17 @@ private extension TestFailureIssueSummary {
             }
         }
         if !value.isEmpty {
-            //            failure.addAttribute(name: "name", stringValue: value)
             let textNode = XMLNode(kind: .text)
             textNode.objectValue = value
             failure.addChild(textNode)
-            failure.addAttribute(name: "message", stringValue: "short")
+            let shortMessage: String
+            if let producingTarget {
+                shortMessage = "\(issueType) in \(producingTarget): \(testCaseName)"
+            } else {
+                shortMessage = "\(issueType): \(testCaseName)"
+            }
+            failure.addAttribute(name: "message", stringValue: shortMessage)
+            failure.addAttribute(name: "type", stringValue: issueType)
         }
         return failure
     }

--- a/Tests/XcresultparserTests/TestAssets/junit.xml
+++ b/Tests/XcresultparserTests/TestAssets/junit.xml
@@ -3,7 +3,7 @@
   <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
     <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
-      <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+      <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
     <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
     <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>

--- a/Tests/XcresultparserTests/TestAssets/junit_merged.xml
+++ b/Tests/XcresultparserTests/TestAssets/junit_merged.xml
@@ -3,7 +3,7 @@
   <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
     <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
-      <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+      <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
     <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
     <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>
@@ -14,7 +14,7 @@
   <testsuite name="XcresultparserTests.xctest" tests="7" failures="1" errors="0" time="4.327">
     <testcase name="testCLIResultFormatter()" time="0.307" classname="XcresultparserTests"/>
     <testcase name="testCoverageConverter()" time="2.818" classname="XcresultparserTests">
-      <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+      <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
     </testcase>
     <testcase name="testHTMLResultFormatter()" time="0.332" classname="XcresultparserTests"/>
     <testcase name="testJunitXMLJunit()" time="0.256" classname="XcresultparserTests"/>

--- a/Tests/XcresultparserTests/TestAssets/sonarTestExecution.xml
+++ b/Tests/XcresultparserTests/TestAssets/sonarTestExecution.xml
@@ -3,7 +3,7 @@
     <file path="XcresultparserTests" configuration="Test Scheme Action">
         <testCase name="testCLIResultFormatter()" duration="307"/>
         <testCase name="testCoverageConverter()" duration="2818">
-            <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+            <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
         </testCase>
         <testCase name="testHTMLResultFormatter()" duration="331"/>
         <testCase name="testJunitXMLJunit()" duration="255"/>

--- a/Tests/XcresultparserTests/TestAssets/sonarTestExecutionWithProjectRootAbsolute.xml
+++ b/Tests/XcresultparserTests/TestAssets/sonarTestExecutionWithProjectRootAbsolute.xml
@@ -3,7 +3,7 @@
     <file path="/Users/actual/project/Tests/XcresultparserTests.swift" configuration="Test Scheme Action">
         <testCase name="testCLIResultFormatter()" duration="307"/>
         <testCase name="testCoverageConverter()" duration="2818">
-            <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+            <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
         </testCase>
         <testCase name="testHTMLResultFormatter()" duration="331"/>
         <testCase name="testJunitXMLJunit()" duration="255"/>

--- a/Tests/XcresultparserTests/TestAssets/sonarTestExecutionWithProjectRootRelative.xml
+++ b/Tests/XcresultparserTests/TestAssets/sonarTestExecutionWithProjectRootRelative.xml
@@ -3,7 +3,7 @@
     <file path="Tests/XcresultparserTests.swift" configuration="Test Scheme Action">
         <testCase name="testCLIResultFormatter()" duration="307"/>
         <testCase name="testCoverageConverter()" duration="2818">
-            <failure message="short">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
+            <failure message="Uncategorized: XcresultparserTests.testCoverageConverter()" type="Uncategorized">failed - Unable to create CoverageConverter from /Users/fhaeser/Library/Developer/Xcode/DerivedData/xcresultparser-ebyquorsyljyyuchjpndxzpxmxvo/Build/Products/Debug/XcresultparserTests.xctest/Contents/Resources/Xcresultparser_XcresultparserTests.bundle/Contents/Resources/test.xcresult (/Users/fhaeser/code/xcresultparser/Tests/XcresultparserTests/XcresultparserTests.swift:108)</failure>
         </testCase>
         <testCase name="testHTMLResultFormatter()" duration="331"/>
         <testCase name="testJunitXMLJunit()" duration="255"/>


### PR DESCRIPTION
## Before

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="15" failures="1" errors="0" time="11.643">
    <testsuite name="NonEmpty-Unit-UnitTests.xctest" tests="15" failures="1" errors="0" time="0.02">
        <testcase name="testArray()" time="0.001" classname="NonEmptyTests"/>
        <testcase name="testCollectionCount()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionFirstWithNonOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionFirstWithOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionLastWithNonOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionLastWithOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionSubscripts()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCustomStringConvertible()" time="0" classname="NonEmptyTests"/>
        <testcase name="testDictionary()" time="0" classname="NonEmptyTests"/>
        <testcase name="testMutableCollectionSubscripts()" time="0" classname="NonEmptyTests"/>
        <testcase name="testNil()" time="0" classname="NonEmptyTests"/>
        <testcase name="testRangeReplaceableCollectionAppend()" time="0" classname="NonEmptyTests"/>
        <testcase name="testRangeReplaceableCollectionAppendSequence()" time="0" classname="NonEmptyTests"/>
        <testcase name="testSet()" time="0.001" classname="NonEmptyTests"/>
        <testcase name="testString()" time="0.014" classname="NonEmptyTests">
            <failure message="short">XCTAssertNil failed: "foo" (/Users/lpadron/Library/Developer/CoreSimulator/Devices/237D0DD7-EB1F-45EE-BB0D-A286B7A937A1/data/Code/CashFoundation/NonEmpty/UnitTests/NonEmptyTests.swift:15)</failure>
        </testcase>
    </testsuite>
</testsuites>
```

## After

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="15" failures="1" errors="0" time="11.643">
    <testsuite name="NonEmpty-Unit-UnitTests.xctest" tests="15" failures="1" errors="0" time="0.02">
        <testcase name="testArray()" time="0.001" classname="NonEmptyTests"/>
        <testcase name="testCollectionCount()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionFirstWithNonOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionFirstWithOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionLastWithNonOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionLastWithOptionalElements()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCollectionSubscripts()" time="0" classname="NonEmptyTests"/>
        <testcase name="testCustomStringConvertible()" time="0" classname="NonEmptyTests"/>
        <testcase name="testDictionary()" time="0" classname="NonEmptyTests"/>
        <testcase name="testMutableCollectionSubscripts()" time="0" classname="NonEmptyTests"/>
        <testcase name="testNil()" time="0" classname="NonEmptyTests"/>
        <testcase name="testRangeReplaceableCollectionAppend()" time="0" classname="NonEmptyTests"/>
        <testcase name="testRangeReplaceableCollectionAppendSequence()" time="0" classname="NonEmptyTests"/>
        <testcase name="testSet()" time="0.001" classname="NonEmptyTests"/>
        <testcase name="testString()" time="0.014" classname="NonEmptyTests">
            <failure message="Uncategorized: NonEmptyTests.testString()" type="Uncategorized">XCTAssertNil failed: "foo" (/Users/lpadron/Library/Developer/CoreSimulator/Devices/237D0DD7-EB1F-45EE-BB0D-A286B7A937A1/data/Code/CashFoundation/NonEmpty/UnitTests/NonEmptyTests.swift:15)</failure>
        </testcase>
    </testsuite>
</testsuites>
```