### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ This tool can read test result data and code coverage data from an .xcarchive us
 
 Parsing the JSON is done using the great [XCResultKit](https://github.com/davidahouse/XCResultKit) package.
 
-## Converting code coverage data
+<details>
+  <summary>More on converting code coverage data</summary>
+  
 ~~Unfortunately converting to the coverage xml format suited for e.g. sonarqube is a tedious task.
 It requires us to invoke the xccov binary for each single file in the project.~~
 
@@ -42,7 +44,7 @@ It my still be useful for you, if you want to just display the contents of the x
 It can also be used for cobertura, thanks to the collaboration of Thibault Wittemberg and maxwell-legrand.
 
 Furthermore it can extract testdata from the xcresult bundle in junit format, also suited for sonarqube.
-
+</details>
 
 ## How to get it
 ### Using homebrew


### PR DESCRIPTION
## Changes

- Removed custom brew tap because `xcresultparser` is supported [in main formulae repo](https://github.com/Homebrew/homebrew-core/blob/main/Formula/x/xcresultparser.rb) since [v1.8.1](https://github.com/Homebrew/homebrew-core/pull/198306)
  - this adds access to precompiled bottles, significantly improving install time
- Moved code coverage info under the spoiler because it was taking too much space, hiding install instructions
  - [check README in this branch](https://github.com/ealeksandrov/xcresultparser/blob/patch-1/README.md) for a demo
